### PR TITLE
Don't run docker rm/rmi if no container/image to remove.

### DIFF
--- a/docker-clean.sh
+++ b/docker-clean.sh
@@ -2,11 +2,11 @@
 
 while true; do
   # Remove exited containers
-  docker rm -v $(docker ps -a -q -f status=exited)
+  docker ps -a -q -f status=exited    | xargs --no-run-if-empty docker rm -v
   # Remove dangling images
-  docker rmi $(docker images -f "dangling=true" -q)
+  docker images -f "dangling=true" -q | xargs --no-run-if-empty docker rmi
   # Remove dangling volumes
-  docker volume rm $(docker volume ls -qf dangling=true)
+  docker volume ls -qf dangling=true  | xargs --no-run-if-empty docker volume rm
 
   # DOCKER_CLEAN_INTERVAL defaults to 30min
   sleep $DOCKER_CLEAN_INTERVAL


### PR DESCRIPTION
If there's no image/container to remove, the container logs activity journal is filled with message of this kind:

```
Remove one or more images
"docker volume rm" requires at least 1 argument(s).
See 'docker volume rm --help'.

Usage:  docker volume rm [OPTIONS] VOLUME [VOLUME...]
```

This PR use xargs with --no-run-if-empty option to avoid unnecessary launches.