### PR TITLE
Remove invalid flag to kubectl get

### DIFF
--- a/k8s-clean.sh
+++ b/k8s-clean.sh
@@ -27,7 +27,7 @@ for job in $finishedJobs; do
 done
 
 # Get unrecycled evicted pods older than 1h
-evictedPods=$(kubectl get pods --all-namespaces -a | grep 'Evicted' | \
+evictedPods=$(kubectl get pods --all-namespaces | grep 'Evicted' | \
   awk 'IF $6 ~ /h|d/ {print $1 "|" $2}')
 
 # Loop through evicted pods and delete them


### PR DESCRIPTION
Hey, I ran into problems running this script with the `-a` flag, so I hope
this is helpful since I had to do this to run it on my cluster.

This command doesn't have a -a flag anymore, at least that I could find.
The command fails to run with the -a flag.